### PR TITLE
(refactor): client uses Context to pass timeouts

### DIFF
--- a/combainer/client.go
+++ b/combainer/client.go
@@ -264,12 +264,13 @@ func (cl *Client) Dispatch(parsingConfigName string, uniqueID string, shouldWait
 		task.PrevTime = startTime.Unix()
 		task.CurrTime = startTime.Add(sessionParameters.WholeTime).Unix()
 		task.CommonTask.Id = uniqueID
+		task.ParsingResult = parsingResult
 
 		cl.Log.WithFields(contextFields).Infof("Send task number %d/%d to aggregate %v", i+1, totalTasksAmount, task)
 		wg.Add(1)
 		go func(t tasks.AggregationTask) {
 			defer wg.Done()
-			cl.doAggregationHandler(wctx, t, hosts, parsingResult)
+			cl.doAggregationHandler(wctx, t, hosts)
 		}(task)
 	}
 	wg.Wait()
@@ -390,8 +391,7 @@ func (cl *Client) doParsingTask(ctx context.Context, task tasks.ParsingTask, m *
 
 }
 
-func (cl *Client) doAggregationHandler(ctx context.Context, task tasks.AggregationTask, hosts []string, r tasks.ParsingResult) {
-	task.ParsingResult = r
+func (cl *Client) doAggregationHandler(ctx context.Context, task tasks.AggregationTask, hosts []string) {
 	_, err := cl.doGeneralTask(ctx, common.AGGREGATE, &task, hosts)
 	if err != nil {
 		cl.clientStats.AddFailedAggregate()

--- a/combainer/context.go
+++ b/combainer/context.go
@@ -1,6 +1,7 @@
 package combainer
 
 import (
+	"github.com/combaine/combaine/combainer/worker"
 	"github.com/combaine/combaine/common/cache"
 
 	"github.com/Sirupsen/logrus"
@@ -10,6 +11,7 @@ type CloudHostsDelegate func() ([]string, error)
 
 type Context struct {
 	*logrus.Logger
-	Cache cache.Cache
-	Hosts CloudHostsDelegate
+	Cache    cache.Cache
+	Hosts    CloudHostsDelegate
+	Resolver worker.Resolver
 }

--- a/combainer/observer.go
+++ b/combainer/observer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/kr/pretty"
 
+	"github.com/combaine/combaine/combainer/worker"
 	"github.com/combaine/combaine/common"
 	"github.com/combaine/combaine/common/configs"
 )
@@ -181,9 +182,10 @@ func Launch(s ServerContext, w http.ResponseWriter, r *http.Request) {
 	logger.Out = w
 
 	ctx := &Context{
-		Logger: logger,
-		Cache:  s.GetContext().Cache,
-		Hosts:  s.GetContext().Hosts,
+		Logger:   logger,
+		Cache:    s.GetContext().Cache,
+		Hosts:    s.GetContext().Hosts,
+		Resolver: worker.NewResolverV11(),
 	}
 
 	cl, err := NewClient(ctx, s.GetRepository())

--- a/combainer/observer.go
+++ b/combainer/observer.go
@@ -159,7 +159,7 @@ func Tasks(s ServerContext, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sp, err := cl.UpdateSessionParams(name)
+	sp, err := cl.updateSessionParams(name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/combainer/worker/resolver.go
+++ b/combainer/worker/resolver.go
@@ -1,0 +1,73 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/cocaine/cocaine-framework-go/cocaine"
+)
+
+var (
+	// ErrAppUnavailable is an application for parsing/aggregating is not found
+	ErrAppUnavailable = fmt.Errorf("Application is unavailable")
+)
+
+// Resolver resolves worker by name
+type Resolver interface {
+	Resolve(ctx context.Context, name string, hosts []string) (Worker, error)
+}
+
+type resolverV11 struct{}
+
+func (r resolverV11) Resolve(ctx context.Context, name string, hosts []string) (Worker, error) {
+	for {
+		host := fmt.Sprintf("%s:10053", getRandomHost(name, hosts))
+		select {
+		case r := <-resolve(name, host):
+			err, app := r.Err, r.App
+			if err == nil {
+				return &workerV11{app}, nil
+			}
+			time.Sleep(50 * time.Millisecond)
+		case <-time.After(1 * time.Second):
+			// pass
+		case <-ctx.Done():
+			return nil, ErrAppUnavailable
+		}
+	}
+}
+
+// NewResolverV11 returns Resolver for Cocaine V11
+func NewResolverV11() Resolver {
+	return resolverV11{}
+}
+
+func getRandomHost(app string, input []string) string {
+	max := len(input)
+	return input[rand.Intn(max)]
+}
+
+type resolveInfo struct {
+	App *cocaine.Service
+	Err error
+}
+
+func resolve(appname, endpoint string) <-chan resolveInfo {
+	res := make(chan resolveInfo)
+	go func() {
+		app, err := cocaine.NewService(appname, endpoint)
+		select {
+		case res <- resolveInfo{
+			App: app,
+			Err: err,
+		}:
+		default:
+			if err == nil {
+				app.Close()
+			}
+		}
+	}()
+	return res
+}

--- a/combainer/worker/worker.go
+++ b/combainer/worker/worker.go
@@ -1,0 +1,67 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cocaine/cocaine-framework-go/cocaine"
+)
+
+var (
+	ErrAppCall = fmt.Errorf("Application call error")
+)
+
+// Future represents asynchronous resutl of a work
+type Future interface {
+	Wait(ctx context.Context, result interface{}) error
+}
+
+type futureV11 struct {
+	ch chan cocaine.ServiceResult
+}
+
+func (f futureV11) Wait(ctx context.Context, result interface{}) error {
+	select {
+	case res := <-f.ch:
+		if res == nil {
+			return ErrAppCall
+		}
+		if res.Err() != nil {
+			return res.Err()
+		}
+		return res.Extract(result)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Worker is an interface on top of Cocaine Workers
+type Worker interface {
+	Do(_ context.Context, name string, args ...interface{}) Future
+	Footprint() string
+	Close()
+}
+
+type workerV11 struct {
+	*cocaine.Service
+}
+
+func NewSlave(app *cocaine.Service) Worker {
+	return &workerV11{
+		Service: app,
+	}
+}
+
+func (s *workerV11) Close() {
+	s.Service.Close()
+}
+
+func (s *workerV11) Do(todo context.Context, name string, args ...interface{}) Future {
+	return futureV11{
+		ch: s.Service.Call(name, args...),
+	}
+}
+
+func (s *workerV11) Footprint() string {
+	return s.Service.Endpoint.AsString()
+}


### PR DESCRIPTION
+ use context.Context to handle timeouts during Dispatch
+ simplify do* interfaces by moving WaitGroup to the call level
+ wrap cocaine.Service into Worker/Resolver pair to simplify the code and make possible migration to v12 easier
+ fix lots of linter warnings (still there are lots of them)
+ tiny refactoring

@sakateka when u have time, please take a look